### PR TITLE
feat: allow to specify custom currency (to replace the default - doll…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Converts Currency Numbers (including decimal points) into words.
 * 0.01 --> zero dollars and one cent
 * 45100 --> forty-five thousand one hundred dollars
 
+* Custom currency
+  - 25.1 --> twenty-five cedis and ten pesewas
+
 
 ### Install
 
@@ -20,17 +23,19 @@ npm install currency-to-words --save
 ### Usage
 
 ```js
-import {CurrencyToWords} from 'currency-to-words'
+import { CurrencyToWords } from 'currency-to-words'
 ```
 
 ```js
 const words = CurrencyToWords(0.01);
+const customCurrency = CurrencyToWords(0.01, 'cedi', 'pesewa' );
 ```
 
 OR
 
 ```js
 const words = CurrencyToWords('105');
+const customCurrency = CurrencyToWords('105', 'cedi', 'pesewa' );
 ```
 
 # TODO

--- a/src/currencyToWords.jsx
+++ b/src/currencyToWords.jsx
@@ -28,17 +28,17 @@ const convertToWords = (currency) => {
   }
 };
 
-const completeDollarWords = (dollars) => {
+const completeDollarWords = (dollars, dollarAmountWord = "dollar") => {
   if (!dollars) dollars = "zero";
-  return dollars + (dollars === "one" ? " dollar" : " dollars");
+  return dollars + (dollars === "one" ? ` ${dollarAmountWord}` : ` ${dollarAmountWord}s`);
 };
 
-const completeCentsWords = (cents) => {
+const completeCentsWords = (cents, centAmountWord = "cent") => {
   if (!cents) return "";
-  return ` and ${cents} ` + (cents === "one" ? "cent" : "cents");
+  return ` and ${cents} ` + (cents === "one" ? `${centAmountWord}` : `${centAmountWord}s`);
 };
 
-export const CurrencyToWords = (value) => {
+export const CurrencyToWords = (value, dollarText = "dollar", centText = "cent") => {
   
   const currency = (value + "").replace(" ", "").split(".");
 
@@ -52,7 +52,7 @@ export const CurrencyToWords = (value) => {
         )
       : "";
 
-  return completeDollarWords(dollarInWords) + completeCentsWords(centsInWords);
+  return completeDollarWords(dollarInWords, dollarText) + completeCentsWords(centsInWords, centText);
 };
 
 export default CurrencyToWords;


### PR DESCRIPTION
Added support for being able to specify a custom currency 
The default remains dollar (for whole numbers) and cent (for a decimal value).

Usage:


```js
import { CurrencyToWords } from 'currency-to-words'
```

```js
const words = CurrencyToWords(0.01);
const customCurrency = CurrencyToWords(0.01, 'cedi', 'pesewa' );
```

OR

```js
const words = CurrencyToWords('105');
const customCurrency = CurrencyToWords('105', 'cedi', 'pesewa' );
```